### PR TITLE
Kamaitachi support

### DIFF
--- a/infinitas_statfetcher/Config.cs
+++ b/infinitas_statfetcher/Config.cs
@@ -15,6 +15,7 @@ namespace infinitas_statfetcher
         public static bool Output_songlist { get; private set; }
         public static bool Save_remote { get; private set; }
         public static bool Save_local { get; private set; }
+        public static bool Save_json { get; private set; }
         public static bool Stream_Playstate { get; private set; }
         public static bool Stream_Marquee { get; private set; }
         public static string MarqueeIdleText { get; private set; }
@@ -39,6 +40,7 @@ namespace infinitas_statfetcher
 
             Save_remote = ReadConfigBoolean("record:saveremote");
             Save_local = ReadConfigBoolean("record:savelocal");
+            Save_json = ReadConfigBoolean("record:savejson");
 
             header.songInfo = ReadConfigBoolean("localrecord:songinfo");
             header.chartDetails = ReadConfigBoolean("localrecord:chartdetails");

--- a/infinitas_statfetcher/Config.cs
+++ b/infinitas_statfetcher/Config.cs
@@ -91,7 +91,7 @@ namespace infinitas_statfetcher
             {
                 sb.Append("\tnotecount\tlevel");
             }
-            sb.Append("\tplaytype\tgrade\tlamp");
+            sb.Append("\tplaytype\tgrade\tlamp\tmisscount");
             if (HeaderConfig.resultDetails)
             {
                 sb.Append("\tgaugepercent\texscore");

--- a/infinitas_statfetcher/PlayData.cs
+++ b/infinitas_statfetcher/PlayData.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Newtonsoft.Json.Linq;
 
 namespace infinitas_statfetcher
 {
@@ -156,6 +157,29 @@ namespace infinitas_statfetcher
             };
 
         }
+        public JObject GetJsonEntry()
+        {
+            JObject json = new JObject();
+            json["score"] = ex;
+            json["lamp"] = expandLamp(clearLamp);
+            json["matchType"] = "songID";
+            json["identifier"] = songID;
+            json["playtype"] = chart.difficulty.Substring(0, 2);
+            json["difficulty"] = chart.difficulty.Substring(2, 1);
+            json["timeAchieved"] = new DateTimeOffset(timestamp).ToUnixTimeSeconds();
+            json["hitData"] = new JObject();
+            json["hitData"]["pgreat"] = judges.pgreat;
+            json["hitData"]["great"] = judges.great;
+            json["hitData"]["good"] = judges.good;
+            json["hitData"]["bad"] = judges.bad;
+            json["hitData"]["poor"] = judges.poor;
+            json["hitMeta"] = new JObject();
+            json["hitMeta"]["fast"] = judges.fast;
+            json["hitMeta"]["slow"] = judges.slow;
+            json["hitMeta"]["comboBreak"] = judges.combobreak;
+            json["hitMeta"]["gauge"] = gauge;
+            return json;
+        }
         public string GetTsvEntry()
         {
             StringBuilder sb = new StringBuilder($"{chart.title}\t{chart.difficulty}");
@@ -182,6 +206,21 @@ namespace infinitas_statfetcher
             }
             sb.Append($"\t{timestamp}");
             return sb.ToString();
+        }
+        string expandLamp(string lamp)
+        {
+            switch (lamp)
+            {
+                case "NP": return "NO PLAY";
+                case "F": return "FAILED";
+                case "AC": return "ASSIST CLEAR";
+                case "EC": return "EASY CLEAR";
+                case "NC": return "CLEAR";
+                case "HC": return "HARD CLEAR";
+                case "EX": return "EX HARD CLEAR";
+                case "FC": return "FULL COMBO";
+            }
+            return "NO PLAY";
         }
     }
 }

--- a/infinitas_statfetcher/PlayData.cs
+++ b/infinitas_statfetcher/PlayData.cs
@@ -27,10 +27,11 @@ namespace infinitas_statfetcher
         int gauge;
         int ex;
         string songID, grade, clearLamp;
-        public bool DataAvailable { get { return settings.DataAvailable; } }
+        public bool DataAvailable { get; private set; }
         public bool PrematureEnd { get { return judges.prematureEnd; } }
         public string ClearState { get { return clearLamp; } }
         public int JudgedNotes { get { return judges.notesJudged; } }
+        public bool MissCountValid { get { return (DataAvailable && !PrematureEnd && settings.assist == "OFF"); } }
 
         public PlayData()
         {
@@ -43,23 +44,34 @@ namespace infinitas_statfetcher
             judges.Fetch(Offsets.JudgeData, Offsets.NotesProgress);
             settings.Fetch(Offsets.PlaySettings, judges.playtype);
 
-            if (!settings.DataAvailable)
-            {
-                Console.WriteLine($"Eww, {(settings.Hran ? "H-RAN" : "Battle")}");
-            }
-
             timestamp = DateTime.UtcNow;
 
             short word = 4;
 
-            var song = Utils.ReadInt32(Offsets.PlayData, 0, word);
-            var diffVal = Utils.ReadInt32(Offsets.PlayData, word, word);
-            var lamp = Utils.ReadInt32(Offsets.PlayData, word * 6, word);
-            gauge = Utils.ReadInt32(Offsets.PlayData, word * 8, word);
+            int diffVal = 0;
+            try
+            {
+                var song = Utils.ReadInt32(Offsets.PlayData, 0, word);
+                diffVal = Utils.ReadInt32(Offsets.PlayData, word, word);
+                var lamp = Utils.ReadInt32(Offsets.PlayData, word * 6, word);
+                gauge = Utils.ReadInt32(Offsets.PlayData, word * 8, word);
 
-            songID = song.ToString("00000");
+                songID = song.ToString("00000");
+                clearLamp = Utils.IntToLamp(lamp);
+                chart = FetchChartInfo(Utils.songDb[songID], diffVal);
+                DataAvailable = true;
+            }
+            catch
+            {
+                Console.WriteLine("Unable to fetch play data, using currentplaying value instead");
+                var currentChart = Utils.FetchCurrentChart();
+                songID = currentChart.id;
+                diffVal = currentChart.diff;
+                clearLamp = "NA"; /* What clear lamp should be given on stuff not sent to server? */
+                chart = FetchChartInfo(Utils.songDb[songID], diffVal);
+                DataAvailable = false;
+            }
 
-            chart = FetchChartInfo(Utils.songDb[songID], diffVal);
 
 
             var maxEx = Utils.songDb[songID].totalNotes[diffVal] * 2;
@@ -101,7 +113,6 @@ namespace infinitas_statfetcher
                 grade = "F";
             }
 
-            clearLamp = Utils.IntToLamp(lamp);
         }
         ChartInfo FetchChartInfo(SongInfo song, int diffVal)
         {
@@ -159,14 +170,25 @@ namespace infinitas_statfetcher
         }
         public JObject GetJsonEntry()
         {
+            var kamaiTask = Network.Kamai_GetSongID(chart.title_english);
+            kamaiTask.Wait();
+            var kamaiID = kamaiTask.Result;
             JObject json = new JObject();
             json["score"] = ex;
             json["lamp"] = expandLamp(clearLamp);
-            json["matchType"] = "songID";
-            json["identifier"] = songID;
+            if (kamaiID == null)
+            {
+                json["matchType"] = "title";
+                json["identifier"] = chart.title;
+            }
+            else
+            {
+                json["matchType"] = "songID";
+                json["identifier"] = kamaiID;
+            }
             json["playtype"] = chart.difficulty.Substring(0, 2);
-            json["difficulty"] = chart.difficulty.Substring(2, 1);
-            json["timeAchieved"] = new DateTimeOffset(timestamp).ToUnixTimeSeconds();
+            json["difficulty"] = expandDifficulty(chart.difficulty.Substring(2, 1));
+            json["timeAchieved"] = new DateTimeOffset(timestamp).ToUnixTimeMilliseconds();
             json["hitData"] = new JObject();
             json["hitData"]["pgreat"] = judges.pgreat;
             json["hitData"]["great"] = judges.great;
@@ -178,6 +200,10 @@ namespace infinitas_statfetcher
             json["hitMeta"]["slow"] = judges.slow;
             json["hitMeta"]["comboBreak"] = judges.combobreak;
             json["hitMeta"]["gauge"] = gauge;
+            if (MissCountValid)
+            {
+                json["hitMeta"]["bp"] = judges.bad + judges.poor;
+            }
             return json;
         }
         public string GetTsvEntry()
@@ -191,7 +217,7 @@ namespace infinitas_statfetcher
             {
                 sb.Append($"\t{chart.totalNotes}\t{chart.level}");
             }
-            sb.Append($"\t{judges.playtype}\t{grade}\t{clearLamp}");
+            sb.Append($"\t{judges.playtype}\t{grade}\t{clearLamp}\t{(MissCountValid ? (judges.poor+judges.bad).ToString() : "-")}");
             if (Config.HeaderConfig.resultDetails)
             {
                 sb.Append($"\t{gauge}\t{ex}");
@@ -207,6 +233,18 @@ namespace infinitas_statfetcher
             sb.Append($"\t{timestamp}");
             return sb.ToString();
         }
+        string expandDifficulty(string diff)
+        {
+            switch (diff)
+            {
+                case "B": return "BEGINNER";
+                case "N": return "NORMAL";
+                case "H": return "HYPER";
+                case "A": return "ANOTHER";
+                case "L": return "LEGGENDARIA";
+            }
+            throw new Exception($"Unexpected difficulty character {diff}");
+        }
         string expandLamp(string lamp)
         {
             switch (lamp)
@@ -220,7 +258,7 @@ namespace infinitas_statfetcher
                 case "EX": return "EX HARD CLEAR";
                 case "FC": return "FULL COMBO";
             }
-            return "NO PLAY";
+            throw new Exception($"Unexpected lamp code {lamp}");
         }
     }
 }

--- a/infinitas_statfetcher/Program.cs
+++ b/infinitas_statfetcher/Program.cs
@@ -144,7 +144,7 @@ namespace infinitas_statfetcher
             if (Config.Save_json)
             {
                 JObject head = new JObject();
-                head["service"] = "BATCH-MANUAL";
+                head["service"] = "Infinitas";
                 head["game"] = "iidx";
                 JObject json = new JObject();
                 json["head"] = head;
@@ -213,7 +213,7 @@ namespace infinitas_statfetcher
                         Thread.Sleep(1000); /* Sleep to avoid race condition */
                         var latestData = new PlayData();
                         latestData.Fetch();
-                        if (latestData.JudgedNotes != 0)
+                        if (latestData.JudgedNotes != 0 && latestData.DataAvailable)
                         {
                             if (Config.Save_remote)
                             {
@@ -232,8 +232,8 @@ namespace infinitas_statfetcher
                                 json["body"] = arr;
                                 File.WriteAllText(jsonfile.FullName, json.ToString());
                             }
-                            Print_PlayData(latestData);
                         }
+                        Print_PlayData(latestData);
                         if (Config.Stream_Playstate)
                         {
                             Utils.Debug("Writing menu state to playstate.txt");
@@ -260,7 +260,7 @@ namespace infinitas_statfetcher
                         }
                         if (Config.Stream_Marquee)
                         {
-                            chart = Utils.FetchCurrentChart();
+                            chart = Utils.CurrentChart();
                             Utils.Debug($"Writing {chart} to marquee.txt");
                             File.WriteAllText("marquee.txt", chart.ToUpper());
                         }

--- a/infinitas_statfetcher/Settings.cs
+++ b/infinitas_statfetcher/Settings.cs
@@ -11,7 +11,6 @@
         public bool battle;
         public bool Hran;
 
-        public bool DataAvailable { get { return !(Hran || battle); } }
         public void Fetch(long position, PlayType playstyle)
         {
             int word = 4;
@@ -50,6 +49,8 @@
                 case 2: style = "R-RANDOM"; break;
                 case 3: style = "S-RANDOM"; break;
                 case 4: style = "MIRROR"; break;
+                case 5: style = "SYNCHRONIZE RANDOM"; break;
+                case 6: style = "SYMMETRY RANDOM"; break;
             }
             switch (style2Val)
             {
@@ -58,12 +59,14 @@
                 case 2: style2 = "R-RANDOM"; break;
                 case 3: style2 = "S-RANDOM"; break;
                 case 4: style2 = "MIRROR"; break;
+                case 5: style2 = "SYNCHRONIZE RANDOM"; break;
+                case 6: style2 = "SYMMETRY RANDOM"; break;
             }
 
             switch (gaugeVal)
             {
                 case 0: gauge = "OFF"; break;
-                case 1: gauge = "ASSISTED EASY"; break;
+                case 1: gauge = "ASSIST EASY"; break;
                 case 2: gauge = "EASY"; break;
                 case 3: gauge = "HARD"; break;
                 case 4: gauge = "EX HARD"; break;

--- a/infinitas_statfetcher/Utils.cs
+++ b/infinitas_statfetcher/Utils.cs
@@ -68,14 +68,24 @@ namespace infinitas_statfetcher
             }
             return GameState.resultScreen;
         }
-        public static string FetchCurrentChart()
+        public static string CurrentChart(bool includeDiff = false)
+        {
+            var values = FetchCurrentChart();
+            return $"{songDb[values.id].title_english}{(includeDiff ? " "+IntToDiff(values.diff) : "")}";
+        }
+        public struct currentChartData
+        {
+            public string id;
+            public int diff;
+        }
+        public static currentChartData FetchCurrentChart()
         {
             byte[] buffer = new byte[32];
             int nRead = 0;
             ReadProcessMemory((int)handle, Offsets.CurrentSong, buffer, buffer.Length, ref nRead);
-            int songid = BytesToInt32(buffer, 0, 32);
-            string song = songDb[songid.ToString("D5")].title_english;
-            return $"{song}";
+            int songid = BytesToInt32(buffer, 0, 4);
+            int diff = BytesToInt32(buffer, 4, 4);
+            return new currentChartData() { id = songid.ToString("D5"), diff = diff };
         }
         public static bool SongListAvailable()
         {

--- a/infinitas_statfetcher/config.ini
+++ b/infinitas_statfetcher/config.ini
@@ -3,8 +3,9 @@ updateFiles = true
 updateserver = "https://raw.githubusercontent.com/olji/infinitas_statfetcher/master/infinitas_statfetcher/"
 
 [Record]
-saveremote = true
+saveremote = false
 savelocal = true
+savejson = true
 
 [RemoteRecord]
 serverAddress = "https://server.here"

--- a/infinitas_statfetcher/infinitas_statfetcher.csproj
+++ b/infinitas_statfetcher/infinitas_statfetcher.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="5.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Add support for manual upload to kamaitachi through json output.

New dependencies: 
- Newtonsoft.Json

Some other fixes that was detected during testing:
- Save miss count, exclude in situations where it's not applicable/irrelevant.
- ANY KEY caused crashes due to missing information about song (memory not filled as clears using ANY KEY isn't saved to eamuse), made a generic solution that should work with any situation where this happens.
